### PR TITLE
Fix CI build: load secrets, switch to signed release APK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: mv app/build/outputs/apk/release/*.apk app/build/outputs/apk/release/blankee.apk
 
       - name: Upload APK Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: blankee-apk
           path: app/build/outputs/apk/release/blankee.apk
+          archive: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -22,14 +22,23 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set up google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
+
       - name: Grant execute permission for Gradle wrapper
         run: chmod +x gradlew
 
-      - name: Build APK
-        run: ./gradlew assembleDebug
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
+
+      - name: Rename APK
+        run: mv app/build/outputs/apk/release/*.apk app/build/outputs/apk/release/blankee.apk
 
       - name: Upload APK Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: blankee-apk
+          path: app/build/outputs/apk/release/blankee.apk


### PR DESCRIPTION
Changes in this PR 
- Fix CI build by loading google-services.json from secrets
- change to release build instead of debug 
- change build file name